### PR TITLE
22 feat/user initialization status

### DIFF
--- a/fastapi-backend/app/db/enums.py
+++ b/fastapi-backend/app/db/enums.py
@@ -15,6 +15,7 @@ class AuthProvider(Enum):
 
 
 class RC(Enum):
+    UNASSIGNED = "UNASSIGNED"  # 초기화 전 기본값
     Torrey = "Torrey"
     JangGiRyeo = "JangGiRyeo"
     Kuyper = "Kuyper"

--- a/fastapi-backend/app/routers/user.py
+++ b/fastapi-backend/app/routers/user.py
@@ -33,12 +33,6 @@ async def initialize_user_info(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db)
 ):
-    # NEW 상태인지 확인
-    if current_user.status != UserStatus.NEW:
-        raise HTTPException(
-            status_code=400, detail="User is already initialized"
-        )
-
     user_service = UserService(db)
     updated_user = user_service.initialize_user_info(current_user, init_data)
     return updated_user

--- a/fastapi-backend/app/routers/user.py
+++ b/fastapi-backend/app/routers/user.py
@@ -1,8 +1,9 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from app.schemas.user import UserResponse, RCUpdate
+from app.schemas.user import UserResponse, RCUpdate, InitializeUserInfo
 from app.db.models import User
+from app.db.enums import UserStatus
 from app.services.user_service import UserService
 from app.db.database import get_db
 from app.dependencies.auth import get_current_user
@@ -23,4 +24,21 @@ async def update_my_rc(
 ):
     user_service = UserService(db)
     updated_user = user_service.update_user_rc(current_user, rc_data.rc)
+    return updated_user
+
+
+@router.patch("/me/initialize", response_model=UserResponse)
+async def initialize_user_info(
+    init_data: InitializeUserInfo,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    # NEW 상태인지 확인
+    if current_user.status != UserStatus.NEW:
+        raise HTTPException(
+            status_code=400, detail="User is already initialized"
+        )
+
+    user_service = UserService(db)
+    updated_user = user_service.initialize_user_info(current_user, init_data)
     return updated_user

--- a/fastapi-backend/app/schemas/user.py
+++ b/fastapi-backend/app/schemas/user.py
@@ -12,6 +12,11 @@ class UserResponse(BaseModel):
     auth_provider: AuthProvider
     rc: RC
     status: UserStatus
+    student_id: Optional[str] = None
+    major: Optional[str] = None
+    phone_number: Optional[str] = None
+    instagram_id: Optional[str] = None
+    mbti: Optional[MBTI] = None
 
     class Config:
         from_attributes = True
@@ -22,6 +27,7 @@ class RCUpdate(BaseModel):
 
 
 class InitializeUserInfo(BaseModel):
+    rc: RC  # 필수(초기화 시 반드시 선택하도록)
     student_id: Optional[str] = None
     major: Optional[str] = None
     phone_number: Optional[str] = None

--- a/fastapi-backend/app/schemas/user.py
+++ b/fastapi-backend/app/schemas/user.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, EmailStr
 from typing import Optional
 
-from app.db.enums import AuthProvider, RC, UserStatus
+from app.db.enums import AuthProvider, RC, UserStatus, MBTI
 
 
 class UserResponse(BaseModel):
@@ -19,3 +19,11 @@ class UserResponse(BaseModel):
 
 class RCUpdate(BaseModel):
     rc: RC
+
+
+class InitializeUserInfo(BaseModel):
+    student_id: Optional[str] = None
+    major: Optional[str] = None
+    phone_number: Optional[str] = None
+    instagram_id: Optional[str] = None
+    mbti: Optional[MBTI] = None

--- a/fastapi-backend/app/services/auth_service.py
+++ b/fastapi-backend/app/services/auth_service.py
@@ -43,7 +43,7 @@ class AuthService:
                 nickname=user_data.get("nickname"),
                 real_name=user_data.get("name"),
                 auth_provider=auth_provider,
-                rc=RC.Torrey,
+                rc=RC.UNASSIGNED,  # 초기화 전 기본값
                 status=UserStatus.NEW
             )
             self.db.add(user)

--- a/fastapi-backend/app/services/auth_service.py
+++ b/fastapi-backend/app/services/auth_service.py
@@ -37,16 +37,18 @@ class AuthService:
         ).first()
 
         if not user:
+            # 새 유저 (처음 로그인) → NEW 상태로 생성
             user = User(
                 email=email,
                 nickname=user_data.get("nickname"),
                 real_name=user_data.get("name"),
                 auth_provider=auth_provider,
                 rc=RC.Torrey,
-                status=UserStatus.ACTIVE
+                status=UserStatus.NEW
             )
             self.db.add(user)
         else:
+            # 기존 유저 (이전에 로그인했던) → ACTIVE 유지
             user.last_login_at = datetime.now(timezone.utc)
 
         self.db.commit()

--- a/fastapi-backend/app/services/user_service.py
+++ b/fastapi-backend/app/services/user_service.py
@@ -1,7 +1,8 @@
 from sqlalchemy.orm import Session
 
 from app.db.models import User
-from app.db.enums import RC
+from app.db.enums import RC, UserStatus
+from app.schemas.user import InitializeUserInfo
 
 
 class UserService:
@@ -10,6 +11,26 @@ class UserService:
 
     def update_user_rc(self, user: User, new_rc: RC) -> User:
         user.rc = new_rc
+        self.db.commit()
+        self.db.refresh(user)
+        return user
+
+    def initialize_user_info(self, user: User, init_data: InitializeUserInfo) -> User:
+        # 필드 업데이트
+        if init_data.student_id is not None:
+            user.student_id = init_data.student_id
+        if init_data.major is not None:
+            user.major = init_data.major
+        if init_data.phone_number is not None:
+            user.phone_number = init_data.phone_number
+        if init_data.instagram_id is not None:
+            user.instagram_id = init_data.instagram_id
+        if init_data.mbti is not None:
+            user.mbti = init_data.mbti
+
+        # NEW → ACTIVE로 변경
+        user.status = UserStatus.ACTIVE
+
         self.db.commit()
         self.db.refresh(user)
         return user

--- a/fastapi-backend/app/services/user_service.py
+++ b/fastapi-backend/app/services/user_service.py
@@ -16,22 +16,26 @@ class UserService:
         return user
 
     def initialize_user_info(self, user: User, init_data: InitializeUserInfo) -> User:
-        # 필드 업데이트 (UNASSIGNED → 실제 RC)
-        user.rc = init_data.rc  # 필수 필드이므로 항상 업데이트
-        if init_data.student_id is not None:
-            user.student_id = init_data.student_id
-        if init_data.major is not None:
-            user.major = init_data.major
-        if init_data.phone_number is not None:
-            user.phone_number = init_data.phone_number
-        if init_data.instagram_id is not None:
-            user.instagram_id = init_data.instagram_id
-        if init_data.mbti is not None:
-            user.mbti = init_data.mbti
+        # NEW 유저만 초기화 처리
+        if user.status == UserStatus.NEW:
+            # 필드 업데이트 (UNASSIGNED → 실제 RC)
+            user.rc = init_data.rc  # 필수 필드이므로 항상 업데이트
+            if init_data.student_id is not None:
+                user.student_id = init_data.student_id
+            if init_data.major is not None:
+                user.major = init_data.major
+            if init_data.phone_number is not None:
+                user.phone_number = init_data.phone_number
+            if init_data.instagram_id is not None:
+                user.instagram_id = init_data.instagram_id
+            if init_data.mbti is not None:
+                user.mbti = init_data.mbti
 
-        # NEW → ACTIVE로 변경
-        user.status = UserStatus.ACTIVE
+            # NEW → ACTIVE로 변경
+            user.status = UserStatus.ACTIVE
 
-        self.db.commit()
-        self.db.refresh(user)
+            self.db.commit()
+            self.db.refresh(user)
+        
+        # ACTIVE 유저는 그냥 현재 유저 정보 반환 (변경 없음)
         return user

--- a/fastapi-backend/app/services/user_service.py
+++ b/fastapi-backend/app/services/user_service.py
@@ -16,7 +16,8 @@ class UserService:
         return user
 
     def initialize_user_info(self, user: User, init_data: InitializeUserInfo) -> User:
-        # 필드 업데이트
+        # 필드 업데이트 (UNASSIGNED → 실제 RC)
+        user.rc = init_data.rc  # 필수 필드이므로 항상 업데이트
         if init_data.student_id is not None:
             user.student_id = init_data.student_id
         if init_data.major is not None:

--- a/fastapi-backend/migrations/versions/1124ee53cbcf_add_unassigned_to_rc_enum.py
+++ b/fastapi-backend/migrations/versions/1124ee53cbcf_add_unassigned_to_rc_enum.py
@@ -1,0 +1,63 @@
+"""add_unassigned_to_rc_enum
+
+Revision ID: 1124ee53cbcf
+Revises: ae06d63ee130
+Create Date: 2026-01-28 14:49:48.730062
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1124ee53cbcf'
+down_revision: Union[str, Sequence[str], None] = 'ae06d63ee130'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # PostgreSQL enum에 값을 추가하려면 타입을 재생성해야 함
+    
+    # 1. 임시 enum 타입 생성 (UNASSIGNED 포함)
+    op.execute("CREATE TYPE rc_new AS ENUM ('UNASSIGNED', 'Torrey', 'JangGiRyeo', 'Kuyper', 'SonYangWon', 'Philadelphos', 'Carmichael')")
+    
+    # 2. 기존 컬럼을 새 enum 타입으로 변경
+    op.execute("""
+        ALTER TABLE users 
+        ALTER COLUMN rc TYPE rc_new 
+        USING rc::text::rc_new
+    """)
+    
+    # 3. 기존 enum 타입 삭제
+    op.execute("DROP TYPE rc")
+    
+    # 4. 새 enum 타입 이름을 기존 이름으로 변경
+    op.execute("ALTER TYPE rc_new RENAME TO rc")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # UNASSIGNED를 제거하고 원래 enum으로 복원
+    
+    # 1. UNASSIGNED 값을 가진 유저를 Torrey로 변경
+    op.execute("UPDATE users SET rc = 'Torrey' WHERE rc = 'UNASSIGNED'")
+    
+    # 2. 임시 enum 타입 생성 (UNASSIGNED 제외)
+    op.execute("CREATE TYPE rc_old AS ENUM ('Torrey', 'JangGiRyeo', 'Kuyper', 'SonYangWon', 'Philadelphos', 'Carmichael')")
+    
+    # 3. 기존 컬럼을 원래 enum 타입으로 변경
+    op.execute("""
+        ALTER TABLE users 
+        ALTER COLUMN rc TYPE rc_old 
+        USING rc::text::rc_old
+    """)
+    
+    # 4. 새 enum 타입 삭제
+    op.execute("DROP TYPE rc")
+    
+    # 5. 원래 enum 타입 이름으로 변경
+    op.execute("ALTER TYPE rc_old RENAME TO rc")

--- a/fastapi-backend/test_user_initialization.py
+++ b/fastapi-backend/test_user_initialization.py
@@ -1,0 +1,136 @@
+"""
+신규 유저 초기화 플로우 테스트 스크립트
+
+실행 방법:
+    uv run python test_user_initialization.py
+
+이 스크립트는 다음을 확인합니다:
+1. 신규 유저 로그인 시 status=NEW인지 확인
+2. InitializeUserInfo 호출 시 NEW → ACTIVE로 변경되는지 확인
+"""
+import sys
+from sqlalchemy.exc import IntegrityError
+
+from app.db.database import SessionLocal
+from app.db.models import User
+from app.db.enums import AuthProvider, RC, UserStatus
+from app.services.auth_service import AuthService
+from app.services.user_service import UserService
+from app.schemas.user import InitializeUserInfo
+
+
+def test_user_initialization():
+    """신규 유저 초기화 플로우 테스트"""
+    db = SessionLocal()
+    test_email = "test_init@example.com"
+
+    # 기존 테스트 데이터 정리
+    try:
+        db.query(User).filter(User.email == test_email).delete()
+        db.commit()
+        print("✓ 기존 테스트 데이터 정리 완료")
+    except Exception as e:
+        db.rollback()
+        print(f"⚠️  기존 데이터 정리 중 오류 (무시): {e}")
+
+    try:
+        print("=" * 60)
+        print("신규 유저 초기화 플로우 테스트 시작")
+        print("=" * 60)
+
+        # 테스트 1: 신규 유저 로그인 시 status=NEW인지 확인
+        print("\n[테스트 1] 신규 유저 로그인 시 status=NEW 확인")
+        print("-" * 60)
+
+        auth_service = AuthService(db)
+        
+        # 신규 유저 로그인 시뮬레이션 (실제 login 메서드 로직 사용)
+        user_data = {
+            "email": test_email,
+            "nickname": "test_user",
+            "name": "Test User"
+        }
+        
+        # 실제 auth_service.login() 로직과 동일하게 유저 생성
+        # (login은 async이고 토큰을 반환하므로, 여기서는 로직만 시뮬레이션)
+        auth_provider = AuthProvider.GOOGLE
+        existing_user = db.query(User).filter(
+            User.email == test_email,
+            User.auth_provider == auth_provider
+        ).first()
+        
+        if not existing_user:
+            # 새 유저 (처음 로그인) → NEW 상태로 생성
+            new_user = User(
+                email=test_email,
+                nickname=user_data["nickname"],
+                real_name=user_data["name"],
+                auth_provider=auth_provider,
+                rc=RC.UNASSIGNED,
+                status=UserStatus.NEW
+            )
+            db.add(new_user)
+            db.commit()
+            db.refresh(new_user)
+        else:
+            new_user = existing_user
+        
+        print(f"✓ 신규 유저 생성 성공 (ID: {new_user.id})")
+        assert new_user.status == UserStatus.NEW, f"예상: NEW, 실제: {new_user.status}"
+        assert new_user.rc == RC.UNASSIGNED, f"예상: UNASSIGNED, 실제: {new_user.rc}"
+        print(f"✓ status={new_user.status.value} 확인")
+        print(f"✓ rc={new_user.rc.value} 확인")
+
+        # 테스트 2: InitializeUserInfo 호출 시 NEW → ACTIVE로 변경되는지 확인
+        print("\n[테스트 2] InitializeUserInfo 호출 시 NEW → ACTIVE 변경 확인")
+        print("-" * 60)
+
+        user_service = UserService(db)
+        init_data = InitializeUserInfo(
+            rc=RC.Kuyper,
+            student_id="2024123456",
+            major="컴퓨터공학과",
+            phone_number="010-1234-5678",
+            instagram_id="test_instagram",
+            mbti=None
+        )
+
+        updated_user = user_service.initialize_user_info(new_user, init_data)
+        
+        assert updated_user.status == UserStatus.ACTIVE, f"예상: ACTIVE, 실제: {updated_user.status}"
+        assert updated_user.rc == RC.Kuyper, f"예상: Kuyper, 실제: {updated_user.rc}"
+        assert updated_user.student_id == "2024123456", "student_id 업데이트 실패"
+        assert updated_user.major == "컴퓨터공학과", "major 업데이트 실패"
+        assert updated_user.phone_number == "010-1234-5678", "phone_number 업데이트 실패"
+        assert updated_user.instagram_id == "test_instagram", "instagram_id 업데이트 실패"
+        
+        print(f"✓ status={updated_user.status.value}로 변경 확인 (NEW → ACTIVE)")
+        print(f"✓ rc={updated_user.rc.value}로 변경 확인 (UNASSIGNED → Kuyper)")
+        print(f"✓ 모든 필드 업데이트 확인")
+
+        print("\n" + "=" * 60)
+        print("✅ 모든 테스트 통과!")
+        print("=" * 60)
+        return True
+
+    except Exception as e:
+        print(f"\n❌ 테스트 실패: {str(e)}")
+        import traceback
+        traceback.print_exc()
+        return False
+    finally:
+        # 테스트 데이터 정리 (성공/실패 관계없이 항상 실행)
+        try:
+            db.query(User).filter(User.email == test_email).delete()
+            db.commit()
+            print("✓ 테스트 데이터 정리 완료")
+        except Exception as cleanup_error:
+            print(f"⚠️ 테스트 데이터 정리 중 오류: {cleanup_error}")
+            db.rollback()
+        finally:
+            db.close()
+
+
+if __name__ == "__main__":
+    success = test_user_initialization()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## 개요

신규 유저 초기화 기능 추가함.
신규 유저(처음 로그인 한 유저)는 NEW 상태로 생성되며, PATCH /users/me/initialize로 필수 정보 입력 시 ACTIVE로 전환된다.

기존에 User 생성시 RC가 Torrey로 들어가 INSERT되는 로직이었음
Torrey말고 UNASSIGNED enum(RC)을 따로 추가하여 일단 User 생성 후 INSERT시 기본값으로 하였고,
곧바로 InitializeUserInfo 호출하여 본인의 RC로 수정할 수 있도록 하였음

## 관련 이슈

- Close #22 

## 변경된 파일

- `app/services/auth_service.py`: 신규 유저 생성 시 `status=NEW`, `rc=UNASSIGNED` 설정
- `app/services/user_service.py`: `initialize_user_info()` 메서드 추가
- `app/routers/user.py`: `PATCH /me/initialize` 엔드포인트 추가
- `app/schemas/user.py`: `InitializeUserInfo` 추가, `UserResponse` 확장
- `app/db/enums.py`: RC enum에 `UNASSIGNED` 추가
- `migrations/versions/1124ee53cbcf_add_unassigned_to_rc_enum.py`: 마이그레이션 파일 추가함

## 작업 내용

- [x] 신규 유저 생성 시 status=NEW, rc=UNASSIGNED로 설정 (auth_service.py)
- [x] PATCH /users/me/initialize 엔드포인트 추가 (routers/user.py)
- [x] initialize_user_info() 서비스 로직 구현 (services/user_service.py)
- NEW 유저만 초기화 처리 (rc 필수, 기타 정보 선택)
- 초기화 후 NEW → ACTIVE 상태 변경
- ACTIVE 유저는 변경 없이 현재 정보 반환
- [x] InitializeUserInfo 스키마 추가 (schemas/user.py)
- rc 필수, student_id/major/phone_number/instagram_id/mbti는 Optional
- [x] UserResponse에 추가 필드 포함 (student_id, major, phone_number, instagram_id, mbti)
- [x] RC enum에 UNASSIGNED 추가 (enums.py)
- [x] RC enum 마이그레이션 파일 추가 (1124ee53cbcf_add_unassigned_to_rc_enum.py)
- [x] 테스트 파일 추가 (test_user_initialization.py)

## ✅ 테스트

- `test_user_initialization.py`: 신규 유저 생성 및 초기화 플로우 테스트
- 마이그레이션 적용 및 테스트 통과 확인

1. 신규 유저 로그인 시 status=NEW 확인
- 새 유저 생성 시 status=UserStatus.NEW인지 확인
- rc=RC.UNASSIGNED인지 확인

2. InitializeUserInfo 호출 시 NEW → ACTIVE 변경 확인
- InitializeUserInfo 호출 후 status=ACTIVE로 변경되는지 확인
- RC가 UNASSIGNED → 실제 RC로 변경되는지 확인
- 다른 필드들(student_id, major 등)이 업데이트되는지 확인

## 테스트 결과

<img width="575" height="382" alt="스크린샷 2026-01-28 오후 3 26 09" src="https://github.com/user-attachments/assets/d0119913-85c7-4220-9e85-b6847ff5c559" />

## 기타

ENUM 추가는 자동 마이그레이션 파일 생성 시 반영이 되지 않아
1. 수동 마이그레이션 수정
2. 모든 마이그레이션 파일 삭제 & 테이블 드랍 후 변경 내역으로 재생성 
두 가지 방법 중 1. 수동 마이그레이션 수정 방법으로 선택함 (Made In cursor)

<img width="412" height="504" alt="스크린샷 2026-01-28 오후 3 43 37" src="https://github.com/user-attachments/assets/07ba9d1f-4488-4abd-87e1-cb4ab05f3f3e" />

