### PR TITLE
34 feat symmetric key api

### DIFF
--- a/colyseus-server/src/rooms/schema/MyRoomState.ts
+++ b/colyseus-server/src/rooms/schema/MyRoomState.ts
@@ -1,7 +1,6 @@
-import { Schema, type } from "@colyseus/schema";
+import { Schema, type, MapSchema } from "@colyseus/schema";
+import { PlayerState } from "./PlayerState";
 
 export class MyRoomState extends Schema {
-
-  @type("string") mySynchronizedProperty: string = "Hello world";
-
+  @type({ map: PlayerState }) players = new MapSchema<PlayerState>();
 }

--- a/colyseus-server/src/rooms/schema/MyRoomState.ts
+++ b/colyseus-server/src/rooms/schema/MyRoomState.ts
@@ -1,6 +1,7 @@
-import { Schema, type, MapSchema } from "@colyseus/schema";
-import { PlayerState } from "./PlayerState";
+import { Schema, type } from "@colyseus/schema";
 
 export class MyRoomState extends Schema {
-  @type({ map: PlayerState }) players = new MapSchema<PlayerState>();
+
+  @type("string") mySynchronizedProperty: string = "Hello world";
+
 }

--- a/fastapi-backend/app/routers/auth.py
+++ b/fastapi-backend/app/routers/auth.py
@@ -6,8 +6,22 @@ from app.core.oauth import oauth
 from app.core.config import settings
 from app.db.database import get_db
 from app.services.auth_service import AuthService
+from app.schemas.auth import SymmetricKeyResponse
 
 router = APIRouter()
+
+
+@router.get("/key", response_model=SymmetricKeyResponse)
+async def get_symmetric_key():
+    """
+    토큰 검증용 대칭키를 응답 body로 리턴함
+    """
+    if not settings.JWT_SECRET:
+        raise HTTPException(status_code=500, detail="JWT secret not configured")
+    return SymmetricKeyResponse(
+        key=settings.JWT_SECRET,
+        algorithm=settings.JWT_ALGORITHM,
+    )
 
 
 @router.get("/login/{provider}")

--- a/fastapi-backend/app/schemas/auth.py
+++ b/fastapi-backend/app/schemas/auth.py
@@ -7,3 +7,7 @@ class Token(BaseModel):
     user_id: int
     email: str
     nickname: str
+
+class SymmetricKeyResponse(BaseModel): # 이 class대로 json을 만들고 리턴함
+    key: str # 대칭키
+    algorithm: str = "HS256" #  jwt 서명 알고리즘


### PR DESCRIPTION
## 개요

클라이언트가 JWT를 검증할 수 있게, 대칭키를 body로 주는 API를 추가하였다.
응답에는 key, algorithm을 포함함.

향후 key 추가, 비대칭키 알고리즘으로 변경될 예정

## 관련 이슈

- Close #34 

## 작업 내용

- [x] `GET /api/auth/key` 엔드포인트 추가 — 응답 body에 `key`, `algorithm` 반환
- [x] `SymmetricKeyResponse` 스키마 추가 (schemas/auth.py)
- [x] JWT_SECRET 미설정 시 500 에러 반환 처리
