### PR TITLE
39 fix cicd 파이프라이닝 재작업

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# PostgreSQL
+DB_PASSWORD=your_db_password_here
+
+# JWT
+JWT_SECRET=your_jwt_secret_here
+
+# Node
+NODE_ENV=production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,38 +1,34 @@
 name: CI/CD Deployment
 
-# deploy 실행 조건
 on:
   push:
-    branches: ["main"] # main 브랜치에 코드가 push 시
-  workflow_dispatch: # 테스트용 - 수동으로 배포 버튼 클릭시
+    branches: ["main"]
+  workflow_dispatch:
 
 jobs:
   deploy:
-    # 미니 PC의 Runner 에서 실행
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
-      # 최신 코드 가져오기
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Deploy to server
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          port: ${{ secrets.SSH_PORT }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          envs: DB_PASSWORD,JWT_SECRET
+          script: |
+            cd /home/metamong/Metamong_back
+            git pull origin main
 
-      # GitHub Secrets를 사용하여 .env 파일 생성
-      # 서버의 보안을 위해 실제 비밀번호는 GitHub Settings의 Secrets에 저장해야 함.
-      - name: Create .env file
-        run: |
-          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
-          echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> .env
-          echo "NODE_ENV=production" >> .env
-          # 필요한 다른 환경변수가 있다면 여기에 추가하세요.
+            # .env 파일 재생성 (서버에 평문 저장 방지를 위해 매 배포 시 덮어씀)
+            printf "DB_PASSWORD=%s\nJWT_SECRET=%s\nNODE_ENV=production\n" \
+              "$DB_PASSWORD" "$JWT_SECRET" > .env
 
-      # docker compose 실행
-      - name: Docker Compose Deploy
-        run: |
-          # --build: 코드가 바뀌었으므로 새로 이미지를 빌드합니다.
-          # -d: 백그라운드에서 실행합니다.
-          docker compose down
-          docker compose up --build -d
-
-      # 도커 용량 최적화 (안 쓰는 오래된 이미지 삭제) -> 빌드 후 찌꺼기 제거
-      - name: Cleanup unused Docker images
-        run: docker image prune -f
+            docker compose down
+            docker compose up --build -d
+            docker image prune -f
+        env:
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Docker database data
 postgres_data/
+
+# Environment variables
+.env

--- a/fastapi-backend/.env.example
+++ b/fastapi-backend/.env.example
@@ -1,0 +1,17 @@
+# Database
+DATABASE_URL=postgresql://team_admin:your_db_password_here@db:5432/metaverse_db
+DB_PASSWORD=your_db_password_here
+
+# JWT
+JWT_SECRET=your_jwt_secret_here
+JWT_ALGORITHM=HS256
+JWT_EXPIRATION_HOURS=24
+SECRET_KEY=your_secret_key_here
+
+# Google OAuth
+GOOGLE_CLIENT_ID=your_google_client_id_here
+GOOGLE_CLIENT_SECRET=your_google_client_secret_here
+
+# URL
+BACKEND_URL=http://localhost:8000
+FRONTEND_URL=http://localhost:3000


### PR DESCRIPTION
## 개요

`deploy.yml` 수정 (ssh-action) 사용하도록 

## 관련 이슈

- #39 

## 작업 내용

- [ ] `deploy.yml` 수정
- [ ] `.env.example` 생성 (root 에 하나, `fastapi-backend`에 하나)

## 테스트 결과

해당사항 없음

## 기타

루트와 `fastapi-backend`에 있는 `.env` 의 역할이 다릅니다.

루트 `.env`는  Docker Compose 가 최초로 주입하는 변수
`fastapi-backend` 는 FastAPI에서 `config.py`에서 직접 읽는 전체 변수

절대 조심!