### PR TITLE
47 feat add team crud

### DIFF
--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from app.core.config import settings
-from app.routers import auth, user
+from app.routers import auth, user, team
 
 app = FastAPI(title=settings.PROJECT_NAME)
 
@@ -26,6 +26,7 @@ app.add_middleware(SessionMiddleware, secret_key=settings.SECRET_KEY)
 # Router 등록
 app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
 app.include_router(user.router, prefix="/api", tags=["users"])
+app.include_router(team.router, prefix="/api")
 
 
 @app.get("/")

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -26,7 +26,7 @@ app.add_middleware(SessionMiddleware, secret_key=settings.SECRET_KEY)
 # Router 등록
 app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
 app.include_router(user.router, prefix="/api", tags=["users"])
-app.include_router(team.router, prefix="/api")
+app.include_router(team.router, prefix="/api", tags=["team"])
 
 
 @app.get("/")

--- a/fastapi-backend/app/routers/team.py
+++ b/fastapi-backend/app/routers/team.py
@@ -1,10 +1,11 @@
 """
 팀(Team) API 라우터.
 
-팀에 대한 REST API 엔드포인트를 정의합니다.
+팀에 대한 REST API 엔드포인트를 정의한다.
 - POST /teams/create: 팀 생성 (현재 로그인 유저를 소유자로 팀 추가)
 - GET /teams: 팀 목록 조회 (최신 생성순, 인증 불필요)
 - GET /teams/{team_id}: id로 팀 조회 (인증 불필요)
+- PATCH /teams/{team_id}: 팀 이름 수정 (소유자만 가능)
 """
 from typing import List
 
@@ -12,7 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 
-from app.schemas.team import TeamCreate, TeamResponse
+from app.schemas.team import TeamCreate, TeamResponse, TeamUpdate
 from app.db.models import User
 from app.db.database import get_db
 from app.dependencies.auth import get_current_user
@@ -55,10 +56,38 @@ async def list_teams(db: Session = Depends(get_db)):
 @router.get("/{team_id}", response_model=TeamResponse)
 async def get_team(team_id: int, db: Session = Depends(get_db)):
     """
-    팀 id로 팀 정보를 조회합니다. 팀이 없으면 404를 반환합니다.
+    팀 id로 팀 정보를 조회한다. 팀이 없으면 404를 반환한다.
     """
     team_service = TeamService(db)
     team = team_service.get_team_by_id(team_id)
     if team is None:
         raise HTTPException(status_code=404, detail="팀을 찾을 수 없습니다.")
     return team
+
+
+@router.patch("/{team_id}", response_model=TeamResponse)
+async def update_team(
+    team_id: int,
+    update_data: TeamUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    팀 이름을 수정한다. 팀 소유자만 수정 가능하며, 이름 중복 시 400을 반환함.
+    """
+    if not update_data.model_fields_set:
+        raise HTTPException(status_code=400, detail="수정할 필드가 없습니다.")
+    team_service = TeamService(db)
+    team = team_service.get_team_by_id(team_id)
+    if team is None:
+        raise HTTPException(status_code=404, detail="팀을 찾을 수 없습니다.")
+    if team.owner_user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="팀 수정 권한이 없습니다.")
+    try:
+        updated = team_service.update_team(team, update_data)
+        return updated
+    except IntegrityError:
+        raise HTTPException(
+            status_code=400,
+            detail="이미 같은 이름의 팀이 존재합니다.",
+        )

--- a/fastapi-backend/app/routers/team.py
+++ b/fastapi-backend/app/routers/team.py
@@ -1,0 +1,39 @@
+"""
+팀(Team) API 라우터.
+
+팀에 대한 REST API 엔드포인트를 정의합니다.
+- POST /teams: 팀 생성 (현재 로그인 유저를 소유자로 팀 추가)
+- (추후) GET /teams/{id}: id로 팀 조회 등 확장 예정
+"""
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+
+from app.schemas.team import TeamCreate, TeamResponse
+from app.db.models import User
+from app.db.database import get_db
+from app.dependencies.auth import get_current_user
+from app.services.team_service import TeamService
+
+router = APIRouter(prefix="/teams", tags=["teams"])
+
+
+@router.post("/", response_model=TeamResponse)
+async def create_team(
+    create_data: TeamCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    팀을 생성합니다. 인증된 유저가 소유자(owner)가 되며, 팀 이름만 body로 전달합니다.
+    팀 이름이 이미 존재하면 400을 반환합니다.
+    """
+    team_service = TeamService(db)
+    try:
+        team = team_service.create_team(current_user, create_data)
+        return team
+    except IntegrityError:
+        raise HTTPException(
+            status_code=400,
+            detail="이미 같은 이름의 팀이 존재합니다.",
+        )

--- a/fastapi-backend/app/routers/team.py
+++ b/fastapi-backend/app/routers/team.py
@@ -3,8 +3,11 @@
 
 팀에 대한 REST API 엔드포인트를 정의합니다.
 - POST /teams/create: 팀 생성 (현재 로그인 유저를 소유자로 팀 추가)
+- GET /teams: 팀 목록 조회 (최신 생성순, 인증 불필요)
 - GET /teams/{team_id}: id로 팀 조회 (인증 불필요)
 """
+from typing import List
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
@@ -37,6 +40,16 @@ async def create_team(
             status_code=400,
             detail="이미 같은 이름의 팀이 존재합니다.",
         )
+
+
+@router.get("/list", response_model=List[TeamResponse])
+async def list_teams(db: Session = Depends(get_db)):
+    """
+    팀 목록을 조회합니다. 최신 생성순으로 반환하며, 각 팀에 소유자(owner) 정보가 포함.
+    """
+    team_service = TeamService(db)
+    teams = team_service.get_teams()
+    return teams
 
 
 @router.get("/{team_id}", response_model=TeamResponse)

--- a/fastapi-backend/app/routers/team.py
+++ b/fastapi-backend/app/routers/team.py
@@ -18,7 +18,7 @@ from app.services.team_service import TeamService
 router = APIRouter(prefix="/teams", tags=["teams"])
 
 
-@router.post("/", response_model=TeamResponse)
+@router.post("/create", response_model=TeamResponse)
 async def create_team(
     create_data: TeamCreate,
     current_user: User = Depends(get_current_user),

--- a/fastapi-backend/app/routers/team.py
+++ b/fastapi-backend/app/routers/team.py
@@ -2,8 +2,8 @@
 팀(Team) API 라우터.
 
 팀에 대한 REST API 엔드포인트를 정의합니다.
-- POST /teams: 팀 생성 (현재 로그인 유저를 소유자로 팀 추가)
-- (추후) GET /teams/{id}: id로 팀 조회 등 확장 예정
+- POST /teams/create: 팀 생성 (현재 로그인 유저를 소유자로 팀 추가)
+- GET /teams/{team_id}: id로 팀 조회 (인증 불필요)
 """
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
@@ -37,3 +37,15 @@ async def create_team(
             status_code=400,
             detail="이미 같은 이름의 팀이 존재합니다.",
         )
+
+
+@router.get("/{team_id}", response_model=TeamResponse)
+async def get_team(team_id: int, db: Session = Depends(get_db)):
+    """
+    팀 id로 팀 정보를 조회합니다. 팀이 없으면 404를 반환합니다.
+    """
+    team_service = TeamService(db)
+    team = team_service.get_team_by_id(team_id)
+    if team is None:
+        raise HTTPException(status_code=404, detail="팀을 찾을 수 없습니다.")
+    return team

--- a/fastapi-backend/app/routers/team.py
+++ b/fastapi-backend/app/routers/team.py
@@ -36,6 +36,8 @@ async def create_team(
     try:
         team = team_service.create_team(current_user, create_data)
         return team
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except IntegrityError:
         raise HTTPException(
             status_code=400,
@@ -86,6 +88,8 @@ async def update_team(
     try:
         updated = team_service.update_team(team, update_data)
         return updated
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except IntegrityError:
         raise HTTPException(
             status_code=400,

--- a/fastapi-backend/app/schemas/team.py
+++ b/fastapi-backend/app/schemas/team.py
@@ -1,0 +1,30 @@
+"""
+팀(Team) API 요청/응답 스키마.
+
+- TeamCreate: 팀 생성 시 클라이언트가 보내는 body (이름만 필요, 소유자는 로그인 유저로 설정됨)
+- TeamResponse: 팀 생성·조회 시 API가 반환하는 형태 (id, name, owner_user_id, created_at, owner 유저 정보)
+"""
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from app.schemas.user import UserResponse
+
+
+class TeamCreate(BaseModel):
+    """팀 생성 요청 body. 팀 이름만 받고, 소유자(owner)는 인증된 현재 유저로 설정됨."""
+
+    name: str = Field(..., min_length=1, max_length=50, description="팀 이름")
+
+
+class TeamResponse(BaseModel):
+    """팀 API 응답 스키마. DB Team 모델과 동일한 필드 + 소유자(owner) 유저 정보."""
+
+    id: int
+    name: str
+    owner_user_id: int
+    created_at: datetime
+    owner: UserResponse | None = None  # 팀을 만든 유저 정보 (relationship)
+
+    class Config:
+        from_attributes = True

--- a/fastapi-backend/app/schemas/team.py
+++ b/fastapi-backend/app/schemas/team.py
@@ -2,6 +2,7 @@
 팀(Team) API 요청/응답 스키마.
 
 - TeamCreate: 팀 생성 시 클라이언트가 보내는 body (이름만 필요, 소유자는 로그인 유저로 설정됨)
+- TeamUpdate: 팀 수정 시 보내는 body (변경할 필드만, PATCH용)
 - TeamResponse: 팀 생성·조회 시 API가 반환하는 형태 (id, name, owner_user_id, created_at, owner 유저 정보)
 """
 from datetime import datetime
@@ -15,6 +16,12 @@ class TeamCreate(BaseModel):
     """팀 생성 요청 body. 팀 이름만 받고, 소유자(owner)는 인증된 현재 유저로 설정됨."""
 
     name: str = Field(..., min_length=1, max_length=50, description="팀 이름")
+
+
+class TeamUpdate(BaseModel):
+    """팀 수정 요청 body (PATCH). 보내진 필드만 변경됨."""
+
+    name: str | None = Field(None, min_length=1, max_length=50, description="팀 이름")
 
 
 class TeamResponse(BaseModel):

--- a/fastapi-backend/app/services/team_service.py
+++ b/fastapi-backend/app/services/team_service.py
@@ -24,8 +24,11 @@ class TeamService:
         :return: 생성된 Team 엔티티 (owner relationship 로드됨)
         :raises: 이름 중복 시 IntegrityError → 라우터에서 400으로 변환 가능
         """
+        name = create_data.name.strip()
+        if not name:
+            raise ValueError("팀 이름은 공백만으로 할 수 없습니다.")
         team = Team(
-            name=create_data.name.strip(),
+            name=name,
             owner_user_id=owner.id,
         )
         self.db.add(team)
@@ -77,7 +80,10 @@ class TeamService:
         :raises: 이름 중복 시 IntegrityError
         """
         if update_data.name is not None:
-            team.name = update_data.name.strip()
+            name = update_data.name.strip()
+            if not name:
+                raise ValueError("팀 이름은 공백만으로 할 수 없습니다.")
+            team.name = name
         try:
             self.db.commit()
             self.db.refresh(team)

--- a/fastapi-backend/app/services/team_service.py
+++ b/fastapi-backend/app/services/team_service.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session, joinedload
 from sqlalchemy.exc import IntegrityError
 
 from app.db.models import Team, User
-from app.schemas.team import TeamCreate
+from app.schemas.team import TeamCreate, TeamUpdate
 
 
 class TeamService:
@@ -66,3 +66,23 @@ class TeamService:
         # 응답 직렬화 시 owner 사용하므로 미리 로드
         _ = team.owner
         return team
+
+    def update_team(self, team: Team, update_data: TeamUpdate) -> Team:
+        """
+        팀 정보를 수정합니다. (이름 등) 호출 전에 소유자 여부는 라우터에서 검사합니다.
+
+        :param team: 수정할 Team 엔티티
+        :param update_data: 변경할 필드 (name 등)
+        :return: 수정된 Team (owner 로드됨)
+        :raises: 이름 중복 시 IntegrityError
+        """
+        if update_data.name is not None:
+            team.name = update_data.name.strip()
+        try:
+            self.db.commit()
+            self.db.refresh(team)
+            _ = team.owner
+            return team
+        except IntegrityError:
+            self.db.rollback()
+            raise

--- a/fastapi-backend/app/services/team_service.py
+++ b/fastapi-backend/app/services/team_service.py
@@ -38,3 +38,17 @@ class TeamService:
         except IntegrityError:
             self.db.rollback()
             raise
+
+    def get_team_by_id(self, team_id: int) -> Team | None:
+        """
+        팀 id로 팀을 조회합니다. owner 관계까지 로드해 둡니다.
+
+        :param team_id: 조회할 팀 id
+        :return: 팀이 있으면 Team, 없으면 None
+        """
+        team = self.db.query(Team).filter(Team.id == team_id).first()
+        if team is None:
+            return None
+        # 응답 직렬화 시 owner 사용하므로 미리 로드
+        _ = team.owner
+        return team

--- a/fastapi-backend/app/services/team_service.py
+++ b/fastapi-backend/app/services/team_service.py
@@ -1,0 +1,40 @@
+"""
+팀(Team) 비즈니스 로직 서비스.
+
+DB 세션을 받아 팀 생성 등 팀 관련 작업을 수행
+라우터에서는 요청/응답만 다루고, 실제 DB 작업과 검증은 여기서 처리
+"""
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+
+from app.db.models import Team, User
+from app.schemas.team import TeamCreate
+
+
+class TeamService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create_team(self, owner: User, create_data: TeamCreate) -> Team:
+        """
+        팀을 생성합니다. 소유자(owner)는 로그인한 현재 유저로 설정
+
+        :param owner: 팀 소유자 (현재 인증된 유저)
+        :param create_data: 팀 이름 등 생성 요청 데이터
+        :return: 생성된 Team 엔티티 (owner relationship 로드됨)
+        :raises: 이름 중복 시 IntegrityError → 라우터에서 400으로 변환 가능
+        """
+        team = Team(
+            name=create_data.name.strip(),
+            owner_user_id=owner.id,
+        )
+        self.db.add(team)
+        try:
+            self.db.commit()
+            self.db.refresh(team)
+            # 응답에서 owner(유저 정보)를 쓰기 위해 relationship 로드
+            _ = team.owner
+            return team
+        except IntegrityError:
+            self.db.rollback()
+            raise

--- a/fastapi-backend/app/services/team_service.py
+++ b/fastapi-backend/app/services/team_service.py
@@ -4,7 +4,7 @@
 DB 세션을 받아 팀 생성 등 팀 관련 작업을 수행
 라우터에서는 요청/응답만 다루고, 실제 DB 작업과 검증은 여기서 처리
 """
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from sqlalchemy.exc import IntegrityError
 
 from app.db.models import Team, User
@@ -38,6 +38,20 @@ class TeamService:
         except IntegrityError:
             self.db.rollback()
             raise
+
+    def get_teams(self) -> list[Team]:
+        """
+        전체 팀 목록을 조회. 각 팀의 owner 관계까지 한 번에 로드
+
+        :return: 팀 목록 (created_at 등 기준 정렬 가능, 현재는 DB 기본 순서)
+        """
+        teams = (
+            self.db.query(Team)
+            .options(joinedload(Team.owner))
+            .order_by(Team.created_at.desc())
+            .all()
+        )
+        return list(teams)
 
     def get_team_by_id(self, team_id: int) -> Team | None:
         """


### PR DESCRIPTION
## 개요

Team CRUD 중 추가 · 목록 조회 · 팀 id 조회 · 이름 수정 4가지 API 추가함. 

## 관련 이슈

- Close #47

## 작업 내용

- [x] **팀 추가** — `POST /api/teams/create`  
  - Body: `{ "name": "팀 이름" }`
  - owner는 현재 로그인한 유저. 
  - 이름 중복 시 400.
- [x] **팀 목록 조회** — `GET /api/teams/list`  
  - 최신 생성순 정렬
  - 각 팀에 owner 정보 포함.
- [x] **id로 팀 조회** — `GET /api/teams/{team_id}`  
  - 팀 없으면 404.
- [x] **팀 이름 수정** — `PATCH /api/teams/{team_id}`  
  - Body: `{ "name": "수정한 이름" }` 
  - 팀 소유자만 수정 가능. 
  - 이름 중복 시 400

## 테스트 결과

Docker Compose 기동 후 `http://localhost:8000/docs` Swagger에서 동작 확인
- 팀 추가
<img width="1282" height="371" alt="image" src="https://github.com/user-attachments/assets/7dbf6ade-8ddd-467c-807a-540f0db4f619" />
<img width="1267" height="620" alt="image" src="https://github.com/user-attachments/assets/83462ca1-3a16-4a67-834c-ef63c4579ad2" />


- 팀 목록 조회
<img width="1280" height="813" alt="image" src="https://github.com/user-attachments/assets/8b926423-e573-4af1-9a52-b7841d8a4740" />


- id로 팀 조회
<img width="1277" height="946" alt="image" src="https://github.com/user-attachments/assets/7e385894-1c97-4a16-8b60-500afd1113bb" />

- (id로) 팀 이름 수정
<img width="1281" height="462" alt="image" src="https://github.com/user-attachments/assets/629c8ae2-360b-48ca-ad7c-add7447df962" />
<img width="1280" height="532" alt="image" src="https://github.com/user-attachments/assets/2f6a9eb3-15d9-48c5-8887-f75a98ab9d72" />

