### PR TITLE
dotenv 루트 통일, dev 용 로그인 엔드포인트 추가

### DIFF
--- a/colyseus-server/src/index.ts
+++ b/colyseus-server/src/index.ts
@@ -8,6 +8,11 @@
  *
  * See: https://docs.colyseus.io/server/api/#constructor-options
  */
+import dotenv from "dotenv";
+// 루트 .env 우선 로드 (로컬 개발용). Docker에서는 environment: 섹션이 우선하므로 영향 없음
+dotenv.config({ path: "../.env" });
+dotenv.config({ path: ".env" }); // 로컬 오버라이드 (colyseus-server/.env 가 있으면 적용)
+
 import { listen } from "@colyseus/tools";
 
 // Import Colyseus config

--- a/fastapi-backend/app/core/config.py
+++ b/fastapi-backend/app/core/config.py
@@ -22,8 +22,11 @@ class Settings(BaseSettings):
     BACKEND_URL: str = ""
     FRONTEND_URL: str = "" # Unity WEBGL 빌드가 호스팅 될 도메인
 
+    # Environment
+    NODE_ENV: str = "production"
+
     model_config = SettingsConfigDict(
-        env_file=".env"
+        env_file=["../.env", ".env"]  # 루트 .env 우선, fastapi-backend/.env로 로컬 오버라이드 가능
     )
 
 

--- a/fastapi-backend/app/routers/auth.py
+++ b/fastapi-backend/app/routers/auth.py
@@ -4,11 +4,51 @@ from fastapi.responses import RedirectResponse
 
 from app.core.oauth import oauth
 from app.core.config import settings
+from app.core.security import create_access_token
 from app.db.database import get_db
+from app.db.models import User
+from app.db.enums import AuthProvider, RC, UserStatus
 from app.services.auth_service import AuthService
-from app.schemas.auth import SymmetricKeyResponse
+from app.schemas.auth import SymmetricKeyResponse, Token
 
 router = APIRouter()
+
+
+@router.post("/dev-login", response_model=Token)
+def dev_login(db: Session = Depends(get_db)):
+    """
+    개발 환경 전용 로그인 (NODE_ENV=development 시에만 활성화)
+    Unity 에디터에서 WebGL 빌드 없이 테스트용 admin 계정으로 바로 로그인할 때 사용
+    """
+    if settings.NODE_ENV != "development":
+        raise HTTPException(status_code=404, detail="Not found")
+
+    user = db.query(User).filter(
+        User.email == "dev@metamong.local",
+        User.auth_provider == AuthProvider.LOCAL
+    ).first()
+
+    if not user:
+        user = User(
+            email="dev@metamong.local",
+            nickname="DevAdmin",
+            real_name="Dev Admin",
+            auth_provider=AuthProvider.LOCAL,
+            rc=RC.Torrey,
+            status=UserStatus.ACTIVE,
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+
+    token = create_access_token(subject=user.id)
+    return Token(
+        access_token=token,
+        token_type="bearer",
+        user_id=user.id,
+        email=user.email,
+        nickname=user.nickname,
+    )
 
 
 @router.get("/key", response_model=SymmetricKeyResponse)


### PR DESCRIPTION
## 개요

1. colyseus와 fastapi 서버 모두 root 디렉토리의 `.env` 를 사용하도록 변경
2. `/api/auth/dev-login` 으로 개발용 로그인 토큰 발급할 수 있도록 변경 (POST)

## 관련 이슈

- #64 

## 작업 내용

개요와 동일

## 테스트 결과

확인예정


