### PR TITLE
63 feat add get avatar api

### DIFF
--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from app.core.config import settings
-from app.routers import auth, user, team
+from app.routers import auth, user, team, avatar
 
 app = FastAPI(title=settings.PROJECT_NAME)
 
@@ -27,6 +27,7 @@ app.add_middleware(SessionMiddleware, secret_key=settings.SECRET_KEY)
 app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
 app.include_router(user.router, prefix="/api", tags=["users"])
 app.include_router(team.router, prefix="/api", tags=["team"])
+app.include_router(avatar.router, prefix="/api", tags=["avatars"])
 
 
 @app.get("/")

--- a/fastapi-backend/app/routers/avatar.py
+++ b/fastapi-backend/app/routers/avatar.py
@@ -1,8 +1,9 @@
 """
 Avatar API 라우터.
 
-- POST /avatars: 새 아바타 생성 (인증 필요, 현재 유저 소유로 생성)
+- POST /avatars/create: 새 아바타 생성 (인증 필요, 현재 유저 소유로 생성)
 - GET /avatars/{avatar_id}: id로 아바타 조회
+- DELETE /avatars/{avatar_id}: id로 아바타 삭제 (소유자만 가능)
 """
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
@@ -40,3 +41,21 @@ async def get_avatar(avatar_id: int, db: Session = Depends(get_db)):
     if avatar is None:
         raise HTTPException(status_code=404, detail="아바타를 찾을 수 없습니다.")
     return avatar
+
+
+@router.delete("/{avatar_id}", status_code=204)
+async def delete_avatar(
+    avatar_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    아바타 id로 아바타를 삭제합니다. 본인 소유 아바타만 삭제 가능하며, 없으면 404, 권한 없으면 403을 반환합니다.
+    """
+    avatar_service = AvatarService(db)
+    avatar = avatar_service.get_avatar_by_id(avatar_id)
+    if avatar is None:
+        raise HTTPException(status_code=404, detail="아바타를 찾을 수 없습니다.")
+    if avatar.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="본인의 아바타만 삭제할 수 있습니다.")
+    avatar_service.delete_avatar(avatar)

--- a/fastapi-backend/app/routers/avatar.py
+++ b/fastapi-backend/app/routers/avatar.py
@@ -2,7 +2,7 @@
 Avatar API 라우터.
 
 - POST /avatars/create: 새 아바타 생성 (인증 필요, 현재 유저 소유로 생성)
-- GET /avatars: user_id 쿼리로 해당 유저의 모든 아바타 조회
+- GET /avatars/list: 본인 아바타 목록 조회 (인증 필요, 본인만)
 - GET /avatars/{avatar_id}: id로 아바타 조회
 - DELETE /avatars/{avatar_id}: id로 아바타 삭제 (소유자만 가능)
 """
@@ -35,12 +35,15 @@ async def create_avatar(
 
 
 @router.get("/list", response_model=List[AvatarResponse])
-async def list_avatars_by_user(user_id: int, db: Session = Depends(get_db)):
+async def list_avatars_by_user(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
     """
-    user_id로 해당 유저의 모든 아바타를 조회합니다. 빈 목록이면 []를 반환합니다.
+    로그인한 유저(본인)의 모든 아바타를 조회합니다. 본인 외에는 조회할 수 없습니다. 빈 목록이면 []를 반환합니다.
     """
     avatar_service = AvatarService(db)
-    avatars = avatar_service.get_avatars_by_user_id(user_id)
+    avatars = avatar_service.get_avatars_by_user_id(current_user.id)
     return avatars
 
 

--- a/fastapi-backend/app/routers/avatar.py
+++ b/fastapi-backend/app/routers/avatar.py
@@ -2,9 +2,12 @@
 Avatar API 라우터.
 
 - POST /avatars/create: 새 아바타 생성 (인증 필요, 현재 유저 소유로 생성)
+- GET /avatars: user_id 쿼리로 해당 유저의 모든 아바타 조회
 - GET /avatars/{avatar_id}: id로 아바타 조회
 - DELETE /avatars/{avatar_id}: id로 아바타 삭제 (소유자만 가능)
 """
+from typing import List
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
@@ -29,6 +32,16 @@ async def create_avatar(
     avatar_service = AvatarService(db)
     avatar = avatar_service.create_avatar(current_user, create_data)
     return avatar
+
+
+@router.get("/list", response_model=List[AvatarResponse])
+async def list_avatars_by_user(user_id: int, db: Session = Depends(get_db)):
+    """
+    user_id로 해당 유저의 모든 아바타를 조회합니다. 빈 목록이면 []를 반환합니다.
+    """
+    avatar_service = AvatarService(db)
+    avatars = avatar_service.get_avatars_by_user_id(user_id)
+    return avatars
 
 
 @router.get("/{avatar_id}", response_model=AvatarResponse)

--- a/fastapi-backend/app/routers/avatar.py
+++ b/fastapi-backend/app/routers/avatar.py
@@ -1,16 +1,33 @@
 """
 Avatar API 라우터.
 
+- POST /avatars: 새 아바타 생성 (인증 필요, 현재 유저 소유로 생성)
 - GET /avatars/{avatar_id}: id로 아바타 조회
 """
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from app.schemas.avatar import AvatarResponse
+from app.schemas.avatar import AvatarCreate, AvatarResponse
+from app.db.models import User
 from app.db.database import get_db
+from app.dependencies.auth import get_current_user
 from app.services.avatar_service import AvatarService
 
 router = APIRouter(prefix="/avatars", tags=["avatars"])
+
+
+@router.post("/create", response_model=AvatarResponse, status_code=201)
+async def create_avatar(
+    create_data: AvatarCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    새 아바타를 생성합니다. 로그인한 유저가 소유자가 되며, avatar_asset_id와 nickname을 body로 전달합니다.
+    """
+    avatar_service = AvatarService(db)
+    avatar = avatar_service.create_avatar(current_user, create_data)
+    return avatar
 
 
 @router.get("/{avatar_id}", response_model=AvatarResponse)

--- a/fastapi-backend/app/routers/avatar.py
+++ b/fastapi-backend/app/routers/avatar.py
@@ -1,0 +1,25 @@
+"""
+Avatar API 라우터.
+
+- GET /avatars/{avatar_id}: id로 아바타 조회
+"""
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.schemas.avatar import AvatarResponse
+from app.db.database import get_db
+from app.services.avatar_service import AvatarService
+
+router = APIRouter(prefix="/avatars", tags=["avatars"])
+
+
+@router.get("/{avatar_id}", response_model=AvatarResponse)
+async def get_avatar(avatar_id: int, db: Session = Depends(get_db)):
+    """
+    아바타 id로 아바타 정보를 조회합니다. 없으면 404를 반환합니다.
+    """
+    avatar_service = AvatarService(db)
+    avatar = avatar_service.get_avatar_by_id(avatar_id)
+    if avatar is None:
+        raise HTTPException(status_code=404, detail="아바타를 찾을 수 없습니다.")
+    return avatar

--- a/fastapi-backend/app/schemas/avatar.py
+++ b/fastapi-backend/app/schemas/avatar.py
@@ -1,0 +1,16 @@
+"""
+Avatar API 응답 스키마.
+"""
+from pydantic import BaseModel
+
+
+class AvatarResponse(BaseModel):
+    """Avatar 조회 시 API가 반환하는 형태."""
+
+    id: int
+    user_id: int
+    avatar_asset_id: str
+    nickname: str
+
+    class Config:
+        from_attributes = True

--- a/fastapi-backend/app/schemas/avatar.py
+++ b/fastapi-backend/app/schemas/avatar.py
@@ -1,7 +1,14 @@
 """
-Avatar API 응답 스키마.
+Avatar API 요청/응답 스키마.
 """
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+
+class AvatarCreate(BaseModel):
+    """Avatar 생성 요청 body. user_id는 로그인한 유저로 자동 설정."""
+
+    avatar_asset_id: str = Field(..., min_length=1, max_length=100, description="아바타 에셋 ID")
+    nickname: str = Field(..., min_length=1, max_length=50, description="아바타 닉네임")
 
 
 class AvatarResponse(BaseModel):

--- a/fastapi-backend/app/services/avatar_service.py
+++ b/fastapi-backend/app/services/avatar_service.py
@@ -1,0 +1,20 @@
+"""
+Avatar 비즈니스 로직 서비스.
+"""
+from sqlalchemy.orm import Session
+
+from app.db.models import Avatar
+
+
+class AvatarService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def get_avatar_by_id(self, avatar_id: int) -> Avatar | None:
+        """
+        Avatar id로 아바타를 조회합니다.
+
+        :param avatar_id: 조회할 아바타 id
+        :return: 있으면 Avatar, 없으면 None
+        """
+        return self.db.query(Avatar).filter(Avatar.id == avatar_id).first()

--- a/fastapi-backend/app/services/avatar_service.py
+++ b/fastapi-backend/app/services/avatar_service.py
@@ -37,3 +37,12 @@ class AvatarService:
         :return: 있으면 Avatar, 없으면 None
         """
         return self.db.query(Avatar).filter(Avatar.id == avatar_id).first()
+
+    def delete_avatar(self, avatar: Avatar) -> None:
+        """
+        아바타를 삭제합니다. 호출 전에 소유자 여부는 라우터에서 검사합니다.
+
+        :param avatar: 삭제할 Avatar 엔티티
+        """
+        self.db.delete(avatar)
+        self.db.commit()

--- a/fastapi-backend/app/services/avatar_service.py
+++ b/fastapi-backend/app/services/avatar_service.py
@@ -29,6 +29,20 @@ class AvatarService:
         self.db.refresh(avatar)
         return avatar
 
+    def get_avatars_by_user_id(self, user_id: int) -> list[Avatar]:
+        """
+        user_id로 해당 유저의 모든 아바타를 조회합니다.
+
+        :param user_id: 조회할 유저 id
+        :return: 해당 유저의 Avatar 목록
+        """
+        return (
+            self.db.query(Avatar)
+            .filter(Avatar.user_id == user_id)
+            .order_by(Avatar.id)
+            .all()
+        )
+
     def get_avatar_by_id(self, avatar_id: int) -> Avatar | None:
         """
         Avatar id로 아바타를 조회합니다.

--- a/fastapi-backend/app/services/avatar_service.py
+++ b/fastapi-backend/app/services/avatar_service.py
@@ -3,12 +3,31 @@ Avatar 비즈니스 로직 서비스.
 """
 from sqlalchemy.orm import Session
 
-from app.db.models import Avatar
+from app.db.models import Avatar, User
+from app.schemas.avatar import AvatarCreate
 
 
 class AvatarService:
     def __init__(self, db: Session):
         self.db = db
+
+    def create_avatar(self, user: User, create_data: AvatarCreate) -> Avatar:
+        """
+        현재 유저 소유로 새 아바타를 생성합니다.
+
+        :param user: 아바타 소유자 (현재 인증된 유저)
+        :param create_data: avatar_asset_id, nickname
+        :return: 생성된 Avatar 엔티티
+        """
+        avatar = Avatar(
+            user_id=user.id,
+            avatar_asset_id=create_data.avatar_asset_id.strip(),
+            nickname=create_data.nickname.strip(),
+        )
+        self.db.add(avatar)
+        self.db.commit()
+        self.db.refresh(avatar)
+        return avatar
 
     def get_avatar_by_id(self, avatar_id: int) -> Avatar | None:
         """


### PR DESCRIPTION
## 개요

avatar 생성/조회/삭제 api 추가함

## 관련 이슈

- Close #63 

## 작업 내용

- [x] (GET) Avatar id를 기반으로 Avatar 조회
- [x] (GET) User id를 기반으로 해당 유저의 모든 Avatar 조회
- [x] (POST) 새로운 Avatar 생성
- [x] (DELETE) Avatar id를 기반으로 Avatar 삭제


## 테스트 결과

스웩ㅋ어

## 기타
- **POST** api/avatars/create

   <img width="1286" height="369" alt="스크린샷 2026-03-14 오후 8 44 03" src="https://github.com/user-attachments/assets/b3ff6b04-902e-46fa-b42e-59916a78a010" />

   결과
   <img width="1280" height="310" alt="스크린샷 2026-03-14 오후 8 46 43" src="https://github.com/user-attachments/assets/8a6b29af-2633-49f6-9ac2-b29d047cd2df" />

- **GET api/avatars/{avatar_id}**

   <img width="1281" height="288" alt="스크린샷 2026-03-14 오후 8 49 19" src="https://github.com/user-attachments/assets/c2a414aa-4fa5-4b9c-addc-49774da42e4d" />

   결과
   <img width="1284" height="270" alt="스크린샷 2026-03-14 오후 8 49 44" src="https://github.com/user-attachments/assets/1e08e872-5eaf-4c48-9e3d-1fbe1abe4920" />

- **GET** /api/avatars/list

  직접 uid 줄 필요없이 로그인 한 유저의 토큰을 가져옴(get_current_user)
   <img width="1273" height="248" alt="스크린샷 2026-03-14 오후 8 51 24" src="https://github.com/user-attachments/assets/27a80b85-da64-4d1c-b702-9a989f3a5a93" />

   결과
   <img width="1278" height="387" alt="스크린샷 2026-03-14 오후 8 52 57" src="https://github.com/user-attachments/assets/c70c53b8-1f74-4779-ab67-220065b9e62a" />

- **DELETE** /api/avatars/{avatar_id}

   <img width="1289" height="381" alt="스크린샷 2026-03-14 오후 8 54 53" src="https://github.com/user-attachments/assets/c414f238-a84f-49b3-b93b-156745e588eb" />
   
   결과
   <img width="1283" height="174" alt="스크린샷 2026-03-14 오후 8 55 32" src="https://github.com/user-attachments/assets/d81b73a0-6a0b-449c-a0db-e85ace568b01" />
